### PR TITLE
fix(navigation): update DAO URL from hekla subdomain to production

### DIFF
--- a/src/widgets/header/lib/navigation.ts
+++ b/src/widgets/header/lib/navigation.ts
@@ -105,7 +105,7 @@ export const headerNavigation: INavItem[] = [
                 },
                 {
                     name: "Aragon",
-                    href: "https://hekla.dao.taiko.xyz/",
+                    href: "https://dao.taiko.xyz/",
                     icon: "/img/header/aragon.svg",
                 },
             ],


### PR DESCRIPTION
Fixes incorrect DAO redirect that was pointing to https://hekla.dao.taiko.xyz/ instead of https://dao.taiko.xyz/

🤖 Generated with [Claude Code](https://claude.com/claude-code)