### PR TITLE
fix: update AI agent guide title and subtitle

### DIFF
--- a/public/guides/deploy-ai-agent-on-ethereum-l2.md
+++ b/public/guides/deploy-ai-agent-on-ethereum-l2.md
@@ -1,6 +1,6 @@
-# How to Deploy AI Agents on an Ethereum L2
+# How to Deploy AI Agents on Taiko
 
-A guide to building, registering and running autonomous AI Agents on Taiko.
+Deploy autonomous AI agents on Taiko, an Ethereum L2 with sub-cent fees, ERC-8004 support and censorship-resistant sequencing.
 
 ---
 

--- a/public/locales/en/guide-ai-agent.json
+++ b/public/locales/en/guide-ai-agent.json
@@ -1,8 +1,8 @@
 {
     "hero": {
         "label": "Guide",
-        "title": "How to Deploy AI Agents on an Ethereum L2",
-        "subtitle": "A guide to building, registering and running autonomous AI Agents on Taiko"
+        "title": "How to Deploy AI Agents on Taiko",
+        "subtitle": "Deploy autonomous AI agents on Taiko, an Ethereum L2 with sub-cent fees, ERC-8004 support and censorship-resistant sequencing."
     },
     "tldr": {
         "title": "TL;DR",


### PR DESCRIPTION
## Summary
- Update title from "How to Deploy AI Agents on an Ethereum L2" to "How to Deploy AI Agents on Taiko"
- Update subtitle to "Deploy autonomous AI agents on Taiko, an Ethereum L2 with sub-cent fees, ERC-8004 support and censorship-resistant sequencing."
- Changes applied to both the page and the markdown file

🤖 Generated with [Claude Code](https://claude.com/claude-code)