### PR TITLE
feat: add Guides to Learn nav + Copy Markdown button

### DIFF
--- a/public/guides/deploy-ai-agent-on-ethereum-l2.md
+++ b/public/guides/deploy-ai-agent-on-ethereum-l2.md
@@ -1,6 +1,6 @@
-# How to Deploy AI Agents on an Ethereum L2
+# How to Deploy AI Agents on Taiko
 
-A guide to building, registering and running autonomous AI Agents on Taiko.
+Deploy autonomous AI agents on Taiko, an Ethereum L2 with sub-cent fees, ERC-8004 support and censorship-resistant sequencing.
 
 ---
 

--- a/public/locales/en/guide-ai-agent.json
+++ b/public/locales/en/guide-ai-agent.json
@@ -1,8 +1,8 @@
 {
     "hero": {
         "label": "Guide",
-        "title": "How to Deploy AI Agents on an Ethereum L2",
-        "subtitle": "A guide to building, registering and running autonomous AI Agents on Taiko"
+        "title": "How to Deploy AI Agents on Taiko",
+        "subtitle": "Deploy autonomous AI agents on Taiko, an Ethereum L2 with sub-cent fees, ERC-8004 support and censorship-resistant sequencing."
     },
     "tldr": {
         "title": "TL;DR",

--- a/src/widgets/11-guide-screens/ui/01-hero/hero.module.scss
+++ b/src/widgets/11-guide-screens/ui/01-hero/hero.module.scss
@@ -2,18 +2,41 @@
     padding: 70px 0 20px;
 }
 
+.headerRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 20px;
+}
+
+.copyBtn {
+    flex-shrink: 0;
+    padding: 8px 16px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background: #fff;
+    font: 500 14px/1.4 $kFontPublicSans;
+    color: #333;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+
+    &:hover {
+        border-color: #000;
+        color: #000;
+    }
+}
+
 .label {
     font: 600 14px/1.4 $kFontPublicSans;
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: $kColorPink;
-    text-align: center;
     margin-bottom: 16px;
 }
 
 .title {
-    text-align: center;
-    margin: 0 auto;
+    margin: 0;
     max-width: 900px;
 
     font: 500 60px/.9 $kFontClashGrotesk;
@@ -22,8 +45,7 @@
 }
 
 .subtitle {
-    text-align: center;
-    margin: 24px auto 0;
+    margin: 24px 0 0;
     max-width: 700px;
 
     font: 400 20px/1.5 $kFontPublicSans;
@@ -46,6 +68,11 @@
 }
 
 @media screen and (max-width: $kMobileXXL) {
+    .headerRow {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
     .title {
         font-size: 40px;
     }

--- a/src/widgets/11-guide-screens/ui/01-hero/index.tsx
+++ b/src/widgets/11-guide-screens/ui/01-hero/index.tsx
@@ -5,6 +5,19 @@ import css from './hero.module.scss';
 
 export const Hero: React.FC = () => {
     const { t } = useTranslation('guide-ai-agent');
+    const [copied, setCopied] = React.useState(false);
+
+    const handleCopyMarkdown = async () => {
+        try {
+            const res = await fetch('/guides/deploy-ai-agent-on-ethereum-l2.md');
+            const text = await res.text();
+            await navigator.clipboard.writeText(text);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            window.open('/guides/deploy-ai-agent-on-ethereum-l2.md', '_blank');
+        }
+    };
 
     return (
         <section
@@ -12,8 +25,15 @@ export const Hero: React.FC = () => {
             id={GuideScreensEnum.HERO}
         >
             <div className="container">
-                <p className={css.label}>{t('hero.label')}</p>
-                <h1 className={css.title}>{t('hero.title')}</h1>
+                <div className={css.headerRow}>
+                    <div>
+                        <p className={css.label}>{t('hero.label')}</p>
+                        <h1 className={css.title}>{t('hero.title')}</h1>
+                    </div>
+                    <button className={css.copyBtn} onClick={handleCopyMarkdown}>
+                        {copied ? 'Copied!' : 'Copy markdown'}
+                    </button>
+                </div>
                 <p className={css.subtitle}>{t('hero.subtitle')}</p>
             </div>
         </section>

--- a/src/widgets/header/lib/navigation.ts
+++ b/src/widgets/header/lib/navigation.ts
@@ -137,6 +137,19 @@ export const headerNavigation: INavItem[] = [
                     icon: "/img/header/careers.svg",
                 },
             ],
+            [
+                {
+                    name: "Guides",
+                    icon: "/img/header/docs.svg",
+                    children: [
+                        {
+                            name: "Deploy AI Agents on Taiko",
+                            desc: "ERC-8004, sub-cent fees, censorship-resistant sequencing",
+                            href: "/guides/deploy-ai-agent-on-ethereum-l2",
+                        },
+                    ],
+                },
+            ],
         ],
     },
     {


### PR DESCRIPTION
## Summary
- Adds a **Guides** subsection under the **Learn** menu in the hardcoded navigation, with a link to the AI agent deployment guide
- Adds a **Copy markdown** button to the guide page hero (top right), which copies the `.md` file contents to clipboard for AI agent consumption

## Test plan
- [ ] Verify "Guides" appears under Learn in the nav dropdown
- [ ] Verify "Copy markdown" button copies the guide content to clipboard
- [ ] Verify button shows "Copied!" feedback after clicking
- [ ] Verify mobile layout stacks the button below the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)